### PR TITLE
Fixed missing dependency: raster

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: MeanShiftR
 Type: Package
 Title: Tree delineation from lidar using mean shift clustering
-Version: 0.1.0
+Version: 0.1.1
 Author: Nikolai Knapp
 Maintainer: Nikolai Knapp <nikolai.knapp@ufz.de>
 Description: The package allows individual tree crown delineation (ITCD) from 
@@ -23,6 +23,7 @@ Depends:
     Rcpp (>= 0.12.9),
     rgeos,
     sp,
-    tripack
+    tripack,
+    raster
 LinkingTo: Rcpp
 RoxygenNote: 6.0.1


### PR DESCRIPTION
Hi @niknap, I tried to use your package and it didn't work at first; When I tried to vectorize the results with `make_CrownPolygons` it complaint about the `bind()` function because it is from the `raster` package that was not being loaded. I added it to dependencies in `DESCRIPTION` file and use raster::bind to make it clear that it is using `bind()` function from `raster` package, as CRAN recommends.

I also added support for setting the right projection for the SpatialPolygonsDataFrame.